### PR TITLE
Used buildtools are not in mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ assert version[2] < 100, "micro version must be less than 100"
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
@@ -33,6 +34,7 @@ apply plugin: 'android'
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
`com.android.tools.build:gradle:2.3.1` is not available from mavenCentral, but from jcenter. You most likely missed that because recent AndroidStudio versions work around that by default.